### PR TITLE
Fix black screen on Ubuntu

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -47,7 +47,8 @@ class Window(pyglet.window.Window):
                                       samples=16)
         else:
             config = pyglet.gl.Config(major_version=3,
-                                      minor_version=3)
+                                      minor_version=3,
+                                      double_buffer=True)
 
         super().__init__(width=width, height=height, caption=title,
                          resizable=resizable, config=config)


### PR DESCRIPTION
On Ubuntu, a pyglet.window.NoSuchConfigException is raised when antialiasing=False but the window is solid black when antialiasing is disabled.

double_buffer=False in class Window causes the black screen on ubuntu when antialiasing is disabled